### PR TITLE
Implement phase 3 navigation control

### DIFF
--- a/wot_ai/game_modules/navigation/common/constants.py
+++ b/wot_ai/game_modules/navigation/common/constants.py
@@ -4,6 +4,8 @@
 常量定义：集中管理所有魔法数字和配置常量
 """
 
+import math
+
 # =============================
 # 检测相关常量
 # =============================
@@ -106,4 +108,33 @@ MAX_MOVE_DURATION: float = 2.0
 
 # 默认前进持续时间（秒）
 DEFAULT_MOVE_DURATION: float = 0.5
+
+# 方向控制 PID 参数
+HEADING_KP: float = 1.8
+HEADING_KI: float = 0.0
+HEADING_KD: float = 0.3
+HEADING_MAX_OUTPUT: float = 1.2
+
+# PWM / 转向阈值
+HEADING_SMALL_TURN: float = 0.06  # rad
+HEADING_MEDIUM_TURN: float = 0.25  # rad
+HEADING_LARGE_TURN: float = 0.55  # rad
+HEADING_PWM_PULSE: float = 0.05  # 秒
+HEADING_REVERSE_THRESHOLD: float = 0.85
+HEADING_REVERSE_ERROR: float = math.radians(30)
+HEADING_REVERSE_PULSE: float = 0.12
+
+# 局部避障相关
+LOCAL_AVOID_ATTRACT_WEIGHT: float = 1.0
+LOCAL_AVOID_REPEL_WEIGHT: float = 15000.0
+LOCAL_AVOID_REPEL_RADIUS: float = 90.0
+LOCAL_AVOID_DECAY: float = 0.6
+
+# 轨迹在线修正
+PATH_DEVIATION_THRESHOLD: float = 25.0
+PATH_LOCAL_REPLAN_THRESHOLD: float = 70.0
+PATH_ADJUST_LOOKAHEAD: int = 20
+PATH_REPLAN_WINDOW: int = 6
+PATH_SAMPLES_PER_SEGMENT: int = 12
+NAV_MIN_PROGRESS_DISTANCE: float = 5.0
 

--- a/wot_ai/game_modules/navigation/core/heading_controller.py
+++ b/wot_ai/game_modules/navigation/core/heading_controller.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""方向控制器：基于 PID/PD 的实时转向修正"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import math
+
+
+def normalize_angle(angle: float) -> float:
+    """将角度归一化到 [-π, π] 区间"""
+
+    while angle > math.pi:
+        angle -= 2.0 * math.pi
+    while angle < -math.pi:
+        angle += 2.0 * math.pi
+    return angle
+
+
+@dataclass
+class HeadingControlResult:
+    """方向控制输出"""
+
+    error: float
+    command: float
+    heading_target: float
+    heading_now: float
+
+
+class HeadingController:
+    """基于 PID/PD 的方向控制器"""
+
+    def __init__(
+        self,
+        kp: float,
+        ki: float,
+        kd: float,
+        max_output: float,
+        integral_limit: Optional[float] = None,
+    ) -> None:
+        if kp < 0 or ki < 0 or kd < 0:
+            raise ValueError("PID 系数必须为非负数")
+        if max_output <= 0:
+            raise ValueError("max_output 必须为正数")
+
+        self.kp_ = kp
+        self.ki_ = ki
+        self.kd_ = kd
+        self.max_output_ = max_output
+        self.integral_limit_ = integral_limit
+        self.integral_term_: float = 0.0
+        self.prev_error_: Optional[float] = None
+
+    def Reset(self) -> None:
+        """重置控制器状态"""
+
+        self.integral_term_ = 0.0
+        self.prev_error_ = None
+
+    def Update(self, heading_now: float, heading_target: float, dt: float) -> HeadingControlResult:
+        """根据当前角度和目标角度计算转向控制量"""
+
+        if dt <= 0:
+            dt = 1e-3
+
+        error = normalize_angle(heading_target - heading_now)
+
+        if self.ki_ > 0:
+            self.integral_term_ += error * dt
+            if self.integral_limit_ is not None:
+                self.integral_term_ = max(
+                    -self.integral_limit_,
+                    min(self.integral_limit_, self.integral_term_),
+                )
+        else:
+            self.integral_term_ = 0.0
+
+        derivative = 0.0
+        if self.prev_error_ is not None:
+            derivative = (error - self.prev_error_) / dt
+        self.prev_error_ = error
+
+        command = self.kp_ * error + self.ki_ * self.integral_term_ + self.kd_ * derivative
+        command = max(-self.max_output_, min(self.max_output_, command))
+
+        return HeadingControlResult(
+            error=error,
+            command=command,
+            heading_target=heading_target,
+            heading_now=heading_now,
+        )
+

--- a/wot_ai/game_modules/navigation/core/local_avoidance.py
+++ b/wot_ai/game_modules/navigation/core/local_avoidance.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""局部避障：轻量势场模型"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+import math
+
+
+Vector2D = Tuple[float, float]
+
+
+def _normalize(vec: Vector2D) -> Vector2D:
+    norm = math.hypot(vec[0], vec[1])
+    if norm == 0:
+        return (0.0, 0.0)
+    return (vec[0] / norm, vec[1] / norm)
+
+
+def _scale(vec: Vector2D, scale: float) -> Vector2D:
+    return (vec[0] * scale, vec[1] * scale)
+
+
+def _add(v1: Vector2D, v2: Vector2D) -> Vector2D:
+    return (v1[0] + v2[0], v1[1] + v2[1])
+
+
+@dataclass
+class AvoidanceResult:
+    vector: Vector2D
+    attraction: Vector2D
+    repulsion: Vector2D
+    obstacle_count: int
+
+
+class PotentialFieldAvoider:
+    """结合吸引/排斥力的轻量势场避障"""
+
+    def __init__(
+        self,
+        attract_weight: float,
+        repulse_weight: float,
+        repel_radius: float,
+        decay: float,
+        min_distance: float = 1.0,
+    ) -> None:
+        if attract_weight <= 0:
+            raise ValueError("attract_weight 必须为正数")
+        if repulse_weight <= 0:
+            raise ValueError("repulse_weight 必须为正数")
+        if repel_radius <= 0:
+            raise ValueError("repel_radius 必须为正数")
+        if not 0 < decay <= 1.0:
+            raise ValueError("decay 需要在 (0, 1] 内")
+
+        self.attract_weight_ = attract_weight
+        self.repulse_weight_ = repulse_weight
+        self.repel_radius_ = repel_radius
+        self.decay_ = decay
+        self.min_distance_ = min_distance
+
+    def Compute(
+        self,
+        current_pos: Optional[Vector2D],
+        target_pos: Optional[Vector2D],
+        obstacles: Optional[Sequence[Sequence[float]]] = None,
+        minimap_size: Optional[Tuple[int, int]] = None,
+    ) -> Optional[AvoidanceResult]:
+        if current_pos is None or target_pos is None:
+            return None
+
+        obstacles = obstacles or []
+        base_vec = (target_pos[0] - current_pos[0], target_pos[1] - current_pos[1])
+        attraction = _scale(_normalize(base_vec), self.attract_weight_)
+
+        repulsion = (0.0, 0.0)
+        count = 0
+        for obstacle in obstacles:
+            if len(obstacle) < 4:
+                continue
+            cx = 0.5 * (obstacle[0] + obstacle[2])
+            cy = 0.5 * (obstacle[1] + obstacle[3])
+            dx = current_pos[0] - cx
+            dy = current_pos[1] - cy
+            dist = math.hypot(dx, dy)
+            if dist < self.min_distance_:
+                dist = self.min_distance_
+            if dist > self.repel_radius_:
+                continue
+
+            strength = self.repulse_weight_ / (dist * dist)
+            direction = _normalize((dx, dy))
+            repulsion = _add(repulsion, _scale(direction, strength))
+            count += 1
+
+        if minimap_size is not None:
+            w, h = minimap_size
+            margin = self.repel_radius_ * 0.5
+            if current_pos[0] < margin:
+                repulsion = _add(repulsion, (self.repulse_weight_ / (margin * margin), 0.0))
+                count += 1
+            if current_pos[0] > w - margin:
+                repulsion = _add(repulsion, (-self.repulse_weight_ / (margin * margin), 0.0))
+                count += 1
+            if current_pos[1] < margin:
+                repulsion = _add(repulsion, (0.0, self.repulse_weight_ / (margin * margin)))
+                count += 1
+            if current_pos[1] > h - margin:
+                repulsion = _add(repulsion, (0.0, -self.repulse_weight_ / (margin * margin)))
+                count += 1
+
+        combined = _add(attraction, _scale(repulsion, self.decay_))
+        return AvoidanceResult(
+            vector=combined,
+            attraction=attraction,
+            repulsion=repulsion,
+            obstacle_count=count,
+        )
+

--- a/wot_ai/game_modules/navigation/core/navigation_executor.py
+++ b/wot_ai/game_modules/navigation/core/navigation_executor.py
@@ -1,148 +1,260 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-导航执行模块：将路径转换为游戏操作
-"""
+"""第三阶段导航执行：路径跟随 + 局部避障 + 在线修正"""
 
-# 标准库导入
-from typing import List, Tuple, Optional
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
 import math
 import time
 
-# 本地模块导入
+from loguru import logger
+
 from ..common.constants import (
+    DEFAULT_MOVE_DURATION,
     DEFAULT_MOVE_SPEED,
+    DEFAULT_MINIMAP_HEIGHT,
+    DEFAULT_MINIMAP_WIDTH,
     DEFAULT_ROTATION_SMOOTH,
     DEFAULT_UPDATE_INTERVAL,
-    DEFAULT_MOVE_DURATION,
-    MAX_MOVE_DURATION
+    HEADING_KD,
+    HEADING_KI,
+    HEADING_KP,
+    HEADING_LARGE_TURN,
+    HEADING_MAX_OUTPUT,
+    HEADING_MEDIUM_TURN,
+    HEADING_PWM_PULSE,
+    HEADING_REVERSE_ERROR,
+    HEADING_REVERSE_PULSE,
+    HEADING_REVERSE_THRESHOLD,
+    HEADING_SMALL_TURN,
+    LOCAL_AVOID_ATTRACT_WEIGHT,
+    LOCAL_AVOID_DECAY,
+    LOCAL_AVOID_REPEL_RADIUS,
+    LOCAL_AVOID_REPEL_WEIGHT,
+    MAX_MOVE_DURATION,
+    NAV_MIN_PROGRESS_DISTANCE,
+    PATH_ADJUST_LOOKAHEAD,
+    PATH_DEVIATION_THRESHOLD,
+    PATH_LOCAL_REPLAN_THRESHOLD,
+    PATH_REPLAN_WINDOW,
+    PATH_SAMPLES_PER_SEGMENT,
 )
-from loguru import logger
 from ..service.control_service import ControlService
+from .heading_controller import HeadingControlResult, HeadingController, normalize_angle
+from .local_avoidance import PotentialFieldAvoider
+from .path_adjuster import OnlinePathAdjuster
+
 
 class NavigationExecutor:
-    """导航执行器：将路径转换为游戏操作"""
-    
-    def __init__(self, control_service: ControlService, move_speed: float = DEFAULT_MOVE_SPEED, rotation_smooth: float = DEFAULT_ROTATION_SMOOTH):
-        """
-        初始化导航执行器
-        
-        Args:
-            control_service: 控制服务实例
-            move_speed: 移动速度系数
-            rotation_smooth: 转向平滑系数
-        
-        Raises:
-            ValueError: 输入参数无效
-        """
+    """根据阶段三规划执行坦克控制"""
+
+    def __init__(
+        self,
+        control_service: ControlService,
+        move_speed: float = DEFAULT_MOVE_SPEED,
+        rotation_smooth: float = DEFAULT_ROTATION_SMOOTH,
+    ) -> None:
         if control_service is None:
             raise ValueError("control_service不能为None")
-        if not isinstance(move_speed, (int, float)) or move_speed <= 0:
+        if move_speed <= 0:
             raise ValueError("move_speed必须是正数")
-        if not isinstance(rotation_smooth, (int, float)) or rotation_smooth < 0 or rotation_smooth > 1:
+        if not 0 <= rotation_smooth <= 1:
             raise ValueError("rotation_smooth必须在0-1之间")
-        
+
         self.control_service_ = control_service
         self.move_speed_ = move_speed
         self.rotation_smooth_ = rotation_smooth
-        self.current_smoothed_angle_ = 0.0
-        # 路径消费状态
-        self.target_point_offset_ = 5  # 目标点偏移量（选择路径上第几个点作为目标）
-        self.current_target_idx_ = 0  # 当前目标点在路径中的索引
-    
-    def ExecutePath(self, path: List[Tuple[int, int]], current_pos: Optional[Tuple[float, float]], 
-                    update_interval: float = DEFAULT_UPDATE_INTERVAL) -> None:
-        """
-        执行路径
-        
-        Args:
-            path: 路径坐标列表
-            current_pos: 当前位置（小地图坐标，可为None）
-            update_interval: 更新间隔（秒）
-        
-        Raises:
-            ValueError: 输入参数无效
-        """
+
+        # 轨迹跟随状态
+        self.target_point_offset_ = 5
+        self.current_target_idx_ = 0
+        self.min_progress_distance_ = NAV_MIN_PROGRESS_DISTANCE
+
+        # 控制器
+        self.heading_controller_ = HeadingController(
+            kp=HEADING_KP,
+            ki=HEADING_KI,
+            kd=HEADING_KD,
+            max_output=HEADING_MAX_OUTPUT,
+        )
+        self.avoidance_ = PotentialFieldAvoider(
+            attract_weight=LOCAL_AVOID_ATTRACT_WEIGHT,
+            repulse_weight=LOCAL_AVOID_REPEL_WEIGHT,
+            repel_radius=LOCAL_AVOID_REPEL_RADIUS,
+            decay=LOCAL_AVOID_DECAY,
+        )
+        self.path_adjuster_ = OnlinePathAdjuster(
+            deviation_threshold=PATH_DEVIATION_THRESHOLD,
+            replan_threshold=PATH_LOCAL_REPLAN_THRESHOLD,
+            look_ahead=PATH_ADJUST_LOOKAHEAD,
+            segment_window=PATH_REPLAN_WINDOW,
+            samples_per_segment=PATH_SAMPLES_PER_SEGMENT,
+        )
+
+        # PWM 阈值
+        self.small_turn_threshold_ = HEADING_SMALL_TURN
+        self.medium_turn_threshold_ = HEADING_MEDIUM_TURN
+        self.large_turn_threshold_ = HEADING_LARGE_TURN
+        self.micro_pulse_duration_ = HEADING_PWM_PULSE
+        self.reverse_command_threshold_ = HEADING_REVERSE_THRESHOLD
+        self.reverse_error_threshold_ = HEADING_REVERSE_ERROR
+        self.reverse_pulse_duration_ = HEADING_REVERSE_PULSE
+
+    def ExecutePath(
+        self,
+        path: List[Tuple[int, int]],
+        current_pos: Optional[Tuple[float, float]],
+        current_heading: Optional[float] = None,
+        dynamic_obstacles: Optional[Sequence[Sequence[float]]] = None,
+        minimap_size: Optional[Tuple[int, int]] = None,
+        update_interval: float = DEFAULT_UPDATE_INTERVAL,
+    ) -> None:
+        """执行路径并实时纠偏"""
+
         if not path:
             logger.warning("路径为空，无法执行")
             return
-        if not isinstance(path, list):
-            raise ValueError("path必须是列表")
         if update_interval <= 0:
             raise ValueError("update_interval必须是正数")
-        
-        if len(path) == 1:
-            logger.info("已到达目标位置")
-            return
-        
-        # 执行路径的每个点
-        for i, waypoint in enumerate(path[1:], 1):
-            logger.debug(f"前往路径点 {i}/{len(path)-1}: {waypoint}")
-            
-            # 如果当前位置未知，直接执行
-            if current_pos is None:
-                # 转向目标方向
-                if i > 0:
-                    prev_point = path[i-1]
-                    self.RotateToward(waypoint, prev_point)
-                
-                # 前进
-                self.MoveForward(DEFAULT_MOVE_DURATION * self.move_speed_)
-                time.sleep(update_interval)
-            else:
-                # 转向目标
-                self.RotateToward(waypoint, current_pos)
-                
-                # 计算距离
-                distance = math.sqrt(
-                    (waypoint[0] - current_pos[0]) ** 2 + 
-                    (waypoint[1] - current_pos[1]) ** 2
+
+        dynamic_obstacles = dynamic_obstacles or []
+        minimap_size = minimap_size or (DEFAULT_MINIMAP_WIDTH, DEFAULT_MINIMAP_HEIGHT)
+        path = list(path)
+        self.current_target_idx_ = 0
+        last_update = time.time()
+        iterations = 0
+        max_iterations = max(len(path) * 3, 1)
+
+        while self.current_target_idx_ < len(path) - 1 and iterations < max_iterations:
+            iterations += 1
+
+            if current_pos is not None:
+                adjustment = self.path_adjuster_.AdjustPath(path, current_pos, self.current_target_idx_)
+                if adjustment.replanned:
+                    logger.debug(
+                        "路径在线重建 deviation={:.2f}, 新长度={}",
+                        adjustment.deviation,
+                        len(adjustment.path),
+                    )
+                    path = adjustment.path
+                self.current_target_idx_ = min(adjustment.target_idx, len(path) - 1)
+
+            target_idx = min(self.current_target_idx_ + self.target_point_offset_, len(path) - 1)
+            source_point = current_pos if current_pos is not None else path[self.current_target_idx_]
+            target_point = path[target_idx]
+            desired_vec = (
+                target_point[0] - source_point[0],
+                target_point[1] - source_point[1],
+            )
+
+            avoidance_output = None
+            if current_pos is not None:
+                avoidance_output = self.avoidance_.Compute(
+                    current_pos,
+                    target_point,
+                    obstacles=dynamic_obstacles,
+                    minimap_size=minimap_size,
                 )
-                
-                # 根据距离计算前进时间
-                duration = min(distance / 100.0 * self.move_speed_, MAX_MOVE_DURATION)
-                self.MoveForward(duration)
-                
-                # 更新当前位置（假设已经到达）
-                current_pos = waypoint
-                time.sleep(update_interval)
-    
-    def RotateToward(self, target_pos: Tuple[float, float], current_pos: Tuple[float, float], current_heading: float) -> None:
-        """
-        转向目标位置
-        
-        Args:
-            target_pos: 目标位置 (x, y)
-            current_pos: 当前位置 (x, y)
-            current_heading: 当前朝向角度（弧度）
-        """
+            nav_vec = avoidance_output.vector if avoidance_output is not None else desired_vec
+            desired_heading = math.atan2(nav_vec[1], nav_vec[0])
+
+            if current_pos is None or current_heading is None:
+                self.RotateToward(target_point, source_point, current_heading)
+            else:
+                now = time.time()
+                dt = max(now - last_update, 1e-3)
+                heading_result = self.heading_controller_.Update(current_heading, desired_heading, dt)
+                self._apply_heading_command(heading_result)
+                current_heading = normalize_angle(current_heading + heading_result.command)
+                last_update = now
+
+            travel_distance = math.hypot(desired_vec[0], desired_vec[1])
+            duration = min(
+                max(travel_distance / 100.0 * self.move_speed_, DEFAULT_MOVE_DURATION * 0.5),
+                MAX_MOVE_DURATION,
+            )
+            self.MoveForward(duration)
+
+            if current_pos is not None:
+                current_pos = target_point
+            self.current_target_idx_ = target_idx
+
+            if travel_distance < self.min_progress_distance_:
+                self.current_target_idx_ = min(self.current_target_idx_ + 1, len(path) - 1)
+
+            time.sleep(update_interval)
+
+        if iterations >= max_iterations:
+            logger.warning("导航执行提前结束：迭代次数达到上限")
+
+    def RotateToward(
+        self,
+        target_pos: Tuple[float, float],
+        current_pos: Tuple[float, float],
+        current_heading: Optional[float],
+    ) -> None:
+        """转向目标位置（回退路径）"""
+
         self.control_service_.RotateToward(target_pos, current_pos, current_heading)
-    
+
     def MoveForward(self, duration: float) -> None:
-        """
-        前进
-        
-        Args:
-            duration: 持续时间（秒）
-        """
+        """前进"""
+
         self.control_service_.MoveForward(duration)
-    
+
     def EnsureMovingForward(self) -> None:
-        """
-        确保正在持续前进（按下W键）
-        如果已按下则不做任何操作，避免重复按压
-        """
+        """持续按下 W"""
+
         self.control_service_.StartForward()
-    
+
     def StopMoving(self) -> None:
-        """
-        停止移动（释放W键）
-        """
+        """停止前进"""
+
         self.control_service_.StopForward()
-        logger.debug("停止移动")
-    
+        logger.debug("停止前进")
+
     def Stop(self) -> None:
-        """停止移动（释放所有按键）"""
+        """释放所有按键"""
+
         self.StopMoving()
         self.control_service_.Stop()
+
+    def _apply_heading_command(self, result: HeadingControlResult) -> None:
+        """将方向控制量转换为 A/D PWM"""
+
+        signal = result.command
+        magnitude = abs(signal)
+
+        if magnitude < self.small_turn_threshold_:
+            self.control_service_.StopLeft()
+            self.control_service_.StopRight()
+            return
+
+        pulse = (
+            self.micro_pulse_duration_
+            if magnitude < self.medium_turn_threshold_
+            else self.micro_pulse_duration_ * 1.5
+        )
+
+        if signal > 0:
+            self.control_service_.StopLeft()
+            if magnitude < self.large_turn_threshold_:
+                self.control_service_.TapKey('d', pulse)
+                self.control_service_.StopRight()
+            else:
+                self.control_service_.StartRight()
+        else:
+            self.control_service_.StopRight()
+            if magnitude < self.large_turn_threshold_:
+                self.control_service_.TapKey('a', pulse)
+                self.control_service_.StopLeft()
+            else:
+                self.control_service_.StartLeft()
+
+        if (
+            magnitude > self.reverse_command_threshold_
+            and abs(result.error) > self.reverse_error_threshold_
+        ):
+            self.control_service_.TapKey('s', self.reverse_pulse_duration_)
 

--- a/wot_ai/game_modules/navigation/core/path_adjuster.py
+++ b/wot_ai/game_modules/navigation/core/path_adjuster.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""第三阶段：轨迹在线调整"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+import math
+
+from .catmull_rom import catmull_rom_interpolate
+
+Point = Tuple[float, float]
+
+
+def _distance(p1: Point, p2: Point) -> float:
+    return math.hypot(p1[0] - p2[0], p1[1] - p2[1])
+
+
+@dataclass
+class PathAdjustmentResult:
+    path: List[Tuple[int, int]]
+    target_idx: int
+    deviation: float
+    replanned: bool
+
+
+class OnlinePathAdjuster:
+    """根据偏离程度实时修正路径"""
+
+    def __init__(
+        self,
+        deviation_threshold: float,
+        replan_threshold: float,
+        look_ahead: int,
+        segment_window: int,
+        samples_per_segment: int,
+    ) -> None:
+        if deviation_threshold <= 0 or replan_threshold <= 0:
+            raise ValueError("阈值必须大于 0")
+        if replan_threshold < deviation_threshold:
+            raise ValueError("replan_threshold 必须大于 deviation_threshold")
+        self.deviation_threshold_ = deviation_threshold
+        self.replan_threshold_ = replan_threshold
+        self.look_ahead_ = max(3, look_ahead)
+        self.segment_window_ = max(2, segment_window)
+        self.samples_per_segment_ = max(5, samples_per_segment)
+
+    def AdjustPath(
+        self,
+        path: List[Tuple[int, int]],
+        current_pos: Optional[Point],
+        current_idx: int,
+    ) -> PathAdjustmentResult:
+        if not path or current_pos is None:
+            return PathAdjustmentResult(path, current_idx, 0.0, False)
+
+        nearest_idx, min_dist = self._find_nearest_point(path, current_pos, current_idx)
+
+        replanned = False
+        new_path = path
+        new_idx = nearest_idx
+
+        if min_dist > self.replan_threshold_ and len(path) - nearest_idx > 2:
+            new_path = self._regenerate_segment(path, current_pos, nearest_idx)
+            new_idx = max(0, nearest_idx - 1)
+            replanned = True
+        elif min_dist > self.deviation_threshold_:
+            new_idx = nearest_idx
+
+        return PathAdjustmentResult(new_path, new_idx, min_dist, replanned)
+
+    def _find_nearest_point(
+        self,
+        path: List[Tuple[int, int]],
+        current_pos: Point,
+        current_idx: int,
+    ) -> Tuple[int, float]:
+        start = max(0, current_idx - 1)
+        end = min(len(path), current_idx + self.look_ahead_)
+        min_dist = float("inf")
+        nearest_idx = current_idx
+        for idx in range(start, end):
+            dist = _distance(current_pos, path[idx])
+            if dist < min_dist:
+                min_dist = dist
+                nearest_idx = idx
+        return nearest_idx, min_dist
+
+    def _regenerate_segment(
+        self,
+        path: List[Tuple[int, int]],
+        current_pos: Point,
+        anchor_idx: int,
+    ) -> List[Tuple[int, int]]:
+        window_end = min(len(path), anchor_idx + self.segment_window_)
+        control_points: List[Point] = [current_pos]
+        control_points.extend(path[anchor_idx:window_end])
+        if len(control_points) < 2:
+            return path
+
+        interpolated = catmull_rom_interpolate(
+            control_points,
+            num_points_per_segment=self.samples_per_segment_,
+            alpha=0.5,
+        )
+        interpolated_int = [(int(round(x)), int(round(y))) for x, y in interpolated]
+
+        return path[:anchor_idx] + interpolated_int + path[window_end:]
+

--- a/wot_ai/game_modules/navigation/service/control_service.py
+++ b/wot_ai/game_modules/navigation/service/control_service.py
@@ -5,7 +5,7 @@
 """
 
 # 标准库导入
-from typing import Tuple
+from typing import Optional, Tuple
 import math
 import time
 
@@ -90,27 +90,44 @@ class ControlService:
             elif turn_direction == 1:  # 右转
                 self.StartRight()
     
-    def RotateToward(self, target_pos: Tuple[float, float], current_pos: Tuple[float, float], current_heading: float) -> None:
+    def RotateToward(
+        self,
+        target_pos: Tuple[float, float],
+        current_pos: Tuple[float, float],
+        current_heading: Optional[float] = None,
+    ) -> None:
         """
         转向目标位置（使用A/D键）
-        
+
         Args:
             target_pos: 目标位置 (x, y)（小地图坐标）
             current_pos: 当前位置 (x, y)（小地图坐标）
-            current_heading: 当前朝向角度（弧度）
+            current_heading: 当前朝向角度（弧度），未知时自动估计
         """
         # 计算方向向量
         dx = target_pos[0] - current_pos[0]
         dy = target_pos[1] - current_pos[1]
-        
+
         if dx == 0 and dy == 0:
             return
-        
+
         # 计算目标方向角度（弧度）
         target_heading = math.atan2(dy, dx)
-        
+
+        if current_heading is None:
+            current_heading = target_heading
+
         # 使用A/D键调整方向
         self.AdjustDirectionWithAD(current_heading, target_heading)
+
+    def TapKey(self, key: str, duration: float = 0.05) -> None:
+        """短按按键（用于 PWM 控制）"""
+
+        if duration <= 0:
+            return
+        self.PressKey(key)
+        time.sleep(duration)
+        self.ReleaseKey(key)
     
     def MoveForward(self, duration: float = 1.0) -> None:
         """


### PR DESCRIPTION
## Summary
- add standalone heading controller, potential-field avoidance, and path adjustment helpers for the phase-three navigation stack
- rework the navigation executor to blend heading correction, local avoidance, online path retargeting, and PWM-style WASD output
- extend navigation constants and the control service to expose the tunables required by the new behaviours

## Testing
- pytest *(fails: missing optional dependencies cv2/numpy/ultralytics in the test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691993679e28832189813f9741b0479f)